### PR TITLE
Fix bug due to missing triangles after pruning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cygnus
 Title: Tiling for spatial clustering 
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(
     person("Ilya", "Korsunsky", email = "ilya.korsunsky@gmail.com", 
         role = c("cre", "aut"), comment = c(ORCID = "0000-0003-4848-3948")),

--- a/R/utils_initdata.R
+++ b/R/utils_initdata.R
@@ -148,6 +148,9 @@ prune_graph = function(data, thresh_quantile = .95, mincells = 10, thresh = NA) 
     ] %>% 
         as.matrix() %>% 
         igraph::from_edgelist()$fun(directed = FALSE) 
+    # add missing isolated triangles to graph
+    g = igraph::add_vertices(g, nv = nrow(tris) - igraph::gorder(g))
+    
     comps = igraph::components(g)$membership
     tris$comp = factor(comps) 
     

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cygnus
+# Tessera
 
 Algorithm for getting tiles for spatial clustering. 
 


### PR DESCRIPTION
Fixes a bug in which isolated triangles that are at the end of the triangles data table are not included in the edgelist and do not get assigned graph components